### PR TITLE
fix PKGBUILD for build outside of repository

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -21,6 +21,7 @@ check() {
 }
 
 pkgver() {
+	cd "${srcdir}/dnsblock"
 	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 


### PR DESCRIPTION
This produces the correct `pkgver` also for AUR helpers.